### PR TITLE
Build aarch64 Docker images on native aarch64 runner

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -29,7 +29,7 @@ jobs:
 
   build_aarch64_wheels:
     name: Build image for aarch64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
     - uses: actions/checkout@v4
@@ -40,11 +40,6 @@ jobs:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Setup up QEMU
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: arm64
 
     - name: Build and push
       uses: docker/build-push-action@v6

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,6 +2,7 @@ name: Build Image from Dockerfile
 on:
   push:
     branches: [ master ]
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -24,7 +25,7 @@ jobs:
       with:
         file: ./Dockerfile_x86_64
         platforms: linux/amd64
-        push: true
+        push: ${{ github.event_name != 'pull_request' }}
         tags: ghcr.io/${{ github.repository_owner }}/manylinux2014_x86_64-hdf5
 
   build_aarch64_wheels:
@@ -46,5 +47,5 @@ jobs:
       with:
         file: ./Dockerfile_aarch64
         platforms: linux/arm64
-        push: true
+        push: ${{ github.event_name != 'pull_request' }}
         tags: ghcr.io/${{ github.repository_owner }}/manylinux2014_aarch64-hdf5


### PR DESCRIPTION
Now that [native aarch64 runners are available](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/). Hopefully this solves the random segfaults currently affecting emulated aarch64.