### PR TITLE
Upgrade base image from `manylinux2014` to `manylinux_2_28`

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -26,7 +26,7 @@ jobs:
         file: ./Dockerfile_x86_64
         platforms: linux/amd64
         push: ${{ github.event_name != 'pull_request' }}
-        tags: ghcr.io/${{ github.repository_owner }}/manylinux2014_x86_64-hdf5
+        tags: ghcr.io/${{ github.repository_owner }}/manylinux_2_28_x86_64-hdf5
 
   build_aarch64_wheels:
     name: Build image for aarch64
@@ -48,4 +48,4 @@ jobs:
         file: ./Dockerfile_aarch64
         platforms: linux/arm64
         push: ${{ github.event_name != 'pull_request' }}
-        tags: ghcr.io/${{ github.repository_owner }}/manylinux2014_aarch64-hdf5
+        tags: ghcr.io/${{ github.repository_owner }}/manylinux_2_28_aarch64-hdf5

--- a/Dockerfile_aarch64
+++ b/Dockerfile_aarch64
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2014_aarch64
+FROM quay.io/pypa/manylinux_2_28_aarch64
 
 ENV HDF5_VERSION 1.14.6
 ENV HDF5_DIR /usr/local

--- a/Dockerfile_x86_64
+++ b/Dockerfile_x86_64
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2014_x86_64
+FROM quay.io/pypa/manylinux_2_28_x86_64
 
 ENV HDF5_VERSION 1.14.6
 ENV HDF5_DIR /usr/local

--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 Images are published on GitHub container registry:
 
-- [manylinux2014_x86_64-hdf5](https://github.com/orgs/h5py/packages/container/package/manylinux2014_x86_64-hdf5).
-- [manylinux2014_aarch64-hdf5](https://github.com/orgs/h5py/packages/container/package/manylinux2014_aarch64-hdf5).
+- [manylinux_2_28_x86_64-hdf5](https://github.com/orgs/h5py/packages/container/package/manylinux_2_28_x86_64-hdf5).
+- [manylinux_2_28_aarch64-hdf5](https://github.com/orgs/h5py/packages/container/package/manylinux_2_28_aarch64-hdf5).


### PR DESCRIPTION
NumPy dropped support for `manylinux2014` and went to `manylinux_2_28`, as noted in https://github.com/numpy/numpy/releases/tag/v2.3.0
This means we need a matching image to continuously test `h5py` against numpy nightlies on Linux as well as on Python 3.14
`glic 2.28` was released in 2018-08-01. In contrast, we already require HDF5>=1.10.4 (2020-08-10) for building the package.

Note: I don't have commit rights to this repo yet. I wouldn't mind gaining them, but I'm also fine with the alternative :-)