### PR TITLE
Add ppc64le Dockerfile and CI workflow support

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -22,6 +22,11 @@ jobs:
            arch: aarch64
            platforms: linux/arm64
            runs-on: ubuntu-24.04-arm
+         - prefix: manylinux
+           version: '2_28'
+           arch: ppc64le
+           platforms: linux/ppc64le
+           runs-on: ubuntu-24.04-ppc64le
          - prefix: musllinux
            version: '1_2'
            arch: x86_64
@@ -32,6 +37,11 @@ jobs:
            arch: aarch64
            platforms: linux/arm64
            runs-on: ubuntu-24.04-arm
+         - prefix: musllinux
+           version: '1_2'
+           arch: ppc64le
+           platforms: linux/ppc64le
+           runs-on: ubuntu-24.04-ppc64le
     steps:
     - uses: actions/checkout@v4
 

--- a/Dockerfile_manylinux_2_28_ppc64le
+++ b/Dockerfile_manylinux_2_28_ppc64le
@@ -1,6 +1,6 @@
 FROM quay.io/pypa/manylinux_2_28_ppc64le
 
-ENV HDF5_VERSION=1.14.6
+ENV HDF5_VERSION=2.0.0
 ENV HDF5_DIR=/usr/local
 
 COPY install_libaec.sh /tmp/install_libaec.sh

--- a/Dockerfile_manylinux_2_28_ppc64le
+++ b/Dockerfile_manylinux_2_28_ppc64le
@@ -1,0 +1,9 @@
+FROM quay.io/pypa/manylinux_2_28_ppc64le
+
+ENV HDF5_VERSION=1.14.6
+ENV HDF5_DIR=/usr/local
+
+COPY install_libaec.sh /tmp/install_libaec.sh
+RUN bash /tmp/install_libaec.sh
+COPY install_hdf5.sh /tmp/install_hdf5.sh
+RUN bash /tmp/install_hdf5.sh

--- a/Dockerfile_musllinux_1_2_ppc64le
+++ b/Dockerfile_musllinux_1_2_ppc64le
@@ -1,0 +1,9 @@
+FROM quay.io/pypa/musllinux_1_2_ppc64le
+
+ENV HDF5_VERSION=1.14.6
+ENV HDF5_DIR=/usr/local
+
+COPY install_libaec.sh /tmp/install_libaec.sh
+RUN bash /tmp/install_libaec.sh
+COPY install_hdf5.sh /tmp/install_hdf5.sh
+RUN bash /tmp/install_hdf5.sh

--- a/Dockerfile_musllinux_1_2_ppc64le
+++ b/Dockerfile_musllinux_1_2_ppc64le
@@ -1,6 +1,6 @@
 FROM quay.io/pypa/musllinux_1_2_ppc64le
 
-ENV HDF5_VERSION=1.14.6
+ENV HDF5_VERSION=2.0.0
 ENV HDF5_DIR=/usr/local
 
 COPY install_libaec.sh /tmp/install_libaec.sh


### PR DESCRIPTION
**Summary**
This PR adds ppc64le support to the manylinux / musllinux image build infrastructure by introducing a ppc64le-specific Dockerfile and updating the CI workflow to build and publish these images. These images will later be used in h5py to enable wheel builds for the ppc64le architecture.

**Changes in this PR**

- Added a ppc64le Dockerfile for building the manylinux image.
- Updated the GitHub Actions workflow to build and push ppc64le images.
- Integrated ppc64le into the existing build matrix.
- Ensured the build process matches the structure and conventions used for other architectures.

**Purpose**
These Docker images will be consumed in a follow-up PR in the main h5py repository to enable CI and wheel builds for ppc64le using GitHub Actions.

**Note:** The ppc64le image build was validated on our self-hosted ppc64le GHA runner. 
When h5py later enables ppc64le CI (see h5py/h5py#2683), the project will need to 
install our GHA App to access these runners.