### PR TITLE
Build HDF5 2.2.0 into the images

### DIFF
--- a/Dockerfile_manylinux_2_28_aarch64
+++ b/Dockerfile_manylinux_2_28_aarch64
@@ -1,6 +1,6 @@
 FROM quay.io/pypa/manylinux_2_28_aarch64
 
-ENV HDF5_VERSION=2.0.0
+ENV HDF5_VERSION=2.2.0
 ENV HDF5_DIR=/usr/local
 
 COPY install_libaec.sh /tmp/install_libaec.sh

--- a/Dockerfile_manylinux_2_28_ppc64le
+++ b/Dockerfile_manylinux_2_28_ppc64le
@@ -1,6 +1,6 @@
 FROM quay.io/pypa/manylinux_2_28_ppc64le
 
-ENV HDF5_VERSION=2.0.0
+ENV HDF5_VERSION=2.2.0
 ENV HDF5_DIR=/usr/local
 
 COPY install_libaec.sh /tmp/install_libaec.sh

--- a/Dockerfile_manylinux_2_28_x86_64
+++ b/Dockerfile_manylinux_2_28_x86_64
@@ -1,6 +1,6 @@
 FROM quay.io/pypa/manylinux_2_28_x86_64
 
-ENV HDF5_VERSION=2.0.0
+ENV HDF5_VERSION=2.2.0
 ENV HDF5_DIR=/usr/local
 
 COPY install_libaec.sh /tmp/install_libaec.sh

--- a/Dockerfile_musllinux_1_2_aarch64
+++ b/Dockerfile_musllinux_1_2_aarch64
@@ -1,6 +1,6 @@
 FROM quay.io/pypa/musllinux_1_2_aarch64
 
-ENV HDF5_VERSION=2.0.0
+ENV HDF5_VERSION=2.2.0
 ENV HDF5_DIR=/usr/local
 
 COPY install_libaec.sh /tmp/install_libaec.sh

--- a/Dockerfile_musllinux_1_2_ppc64le
+++ b/Dockerfile_musllinux_1_2_ppc64le
@@ -1,6 +1,6 @@
 FROM quay.io/pypa/musllinux_1_2_ppc64le
 
-ENV HDF5_VERSION=2.0.0
+ENV HDF5_VERSION=2.2.0
 ENV HDF5_DIR=/usr/local
 
 COPY install_libaec.sh /tmp/install_libaec.sh

--- a/Dockerfile_musllinux_1_2_x86_64
+++ b/Dockerfile_musllinux_1_2_x86_64
@@ -1,6 +1,6 @@
 FROM quay.io/pypa/musllinux_1_2_x86_64
 
-ENV HDF5_VERSION=2.0.0
+ENV HDF5_VERSION=2.2.0
 ENV HDF5_DIR=/usr/local
 
 COPY install_libaec.sh /tmp/install_libaec.sh

--- a/install_hdf5.sh
+++ b/install_hdf5.sh
@@ -22,11 +22,31 @@ fi
 echo "Downloading & unpacking HDF5 ${HDF5_VERSION}"
 # Releases after 2.1.0 are tagged with the plain version only (e.g. "2.2.0");
 # older releases use the "hdf5_X.Y.Z" tag convention.
-curl -fsSL -o "hdf5-${HDF5_VERSION}.tar.gz" "https://github.com/HDFGroup/hdf5/archive/refs/tags/${HDF5_VERSION}.tar.gz" \
-    || curl -fsSL -o "hdf5-${HDF5_VERSION}.tar.gz" "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_${HDF5_VERSION}.tar.gz"
-mkdir -p "hdf5-${HDF5_VERSION}"
-tar -xzf "hdf5-${HDF5_VERSION}.tar.gz" --strip-components=1 -C "hdf5-${HDF5_VERSION}"
-pushd "hdf5-${HDF5_VERSION}"
+urls=(
+    "https://github.com/HDFGroup/hdf5/archive/refs/tags/${HDF5_VERSION}.tar.gz"
+    "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_${HDF5_VERSION}.tar.gz"
+)
+
+# NB: HDF5_DIR is already taken (the install prefix, set by the Dockerfiles)
+HDF5_SRC_DIR="hdf5-${HDF5_VERSION}"
+HDF5_TARBALL="${HDF5_SRC_DIR}.tar.gz"
+
+set +e
+for url in "${urls[@]}"; do
+    echo "downloading from $url"
+    curl --location "$url" --output "${HDF5_TARBALL}" --fail --silent --show-error
+    if [[ "$?" == 0 ]]; then
+        echo "download succeeded"
+        break
+    else
+        echo "download failed"
+    fi
+done
+set -e
+
+mkdir -p "${HDF5_SRC_DIR}"
+tar -xzf "${HDF5_TARBALL}" --strip-components=1 --directory "${HDF5_SRC_DIR}"
+pushd "${HDF5_SRC_DIR}"
 
 echo "Configuring, building & installing HDF5 ${HDF5_VERSION} to ${HDF5_DIR}"
 mkdir build
@@ -48,8 +68,8 @@ popd
 
 # Clean up to limit the size of the Docker image
 echo "Cleaning up unnecessary files"
-rm -r "hdf5-${HDF5_VERSION}"
-rm "hdf5-${HDF5_VERSION}.tar.gz"
+rm -r "${HDF5_SRC_DIR}"
+rm "${HDF5_TARBALL}"
 
 if which yum; then
     yum erase -y zlib-devel

--- a/install_hdf5.sh
+++ b/install_hdf5.sh
@@ -20,10 +20,13 @@ if which yum; then
 fi
 
 echo "Downloading & unpacking HDF5 ${HDF5_VERSION}"
-HDF5_TAG="hdf5_${HDF5_VERSION}"
-curl -fsSLO "https://github.com/HDFGroup/hdf5/archive/refs/tags/${HDF5_TAG}.tar.gz"
-tar -xzf $HDF5_TAG.tar.gz
-pushd hdf5-$HDF5_TAG
+# Releases after 2.1.0 are tagged with the plain version only (e.g. "2.2.0");
+# older releases use the "hdf5_X.Y.Z" tag convention.
+curl -fsSL -o "hdf5-${HDF5_VERSION}.tar.gz" "https://github.com/HDFGroup/hdf5/archive/refs/tags/${HDF5_VERSION}.tar.gz" \
+    || curl -fsSL -o "hdf5-${HDF5_VERSION}.tar.gz" "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_${HDF5_VERSION}.tar.gz"
+mkdir -p "hdf5-${HDF5_VERSION}"
+tar -xzf "hdf5-${HDF5_VERSION}.tar.gz" --strip-components=1 -C "hdf5-${HDF5_VERSION}"
+pushd "hdf5-${HDF5_VERSION}"
 
 echo "Configuring, building & installing HDF5 ${HDF5_VERSION} to ${HDF5_DIR}"
 mkdir build
@@ -45,8 +48,8 @@ popd
 
 # Clean up to limit the size of the Docker image
 echo "Cleaning up unnecessary files"
-rm -r hdf5-$HDF5_TAG
-rm $HDF5_TAG.tar.gz
+rm -r "hdf5-${HDF5_VERSION}"
+rm "hdf5-${HDF5_VERSION}.tar.gz"
 
 if which yum; then
     yum erase -y zlib-devel


### PR DESCRIPTION
Companion to h5py/h5py#2947 — bumps the HDF5 built into the manylinux/musllinux images from 2.0.0 to 2.2.0.

HDF5 2.0.0 is affected by nine published CVEs fixed upstream in 2.1.0/2.2.0, including CVE-2025-44904 (heap buffer overflow via unvalidated stored chunk size, NVD 8.8 HIGH) and the CVE-2026-17572/17573/17574 batch fixed in 2.2.0. Full list and references in the h5py PR; the HDF Group's tracking is at [HDFGroup/cve_hdf5](https://github.com/HDFGroup/cve_hdf5).

Releases after 2.1.0 are tagged with the plain version only (e.g. `2.2.0` — the `hdf5_X.Y.Z` convention stopped after 2.1.0), so `install_hdf5.sh` now tries the plain tag first and falls back to the old convention.

Tested by building the `manylinux_2_28_aarch64` image locally (podman): HDF5 2.2.0 configures, builds, and installs cleanly; `libhdf5.settings` in the image reports version 2.2.0.

